### PR TITLE
Main change: CharacterNode and AssetNode created

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Adventurer Party Maker
-Adventurer Party Maker is a fun little application that allows you to create scenes by moving characters around, assigning them animations, and using primitive building blocks and color tools to craft an environment. Export features allow for taking pictures and series of photos of your creations.
+# Adventure Party Maker
+Adventure Party Maker is a fun little application that allows you to create scenes by moving characters around, assigning them animations, and using primitive building blocks and color tools to craft an environment. Export features allow for taking pictures and series of photos of your creations.
 
 
 # Project Compilation Procedure on Windows

--- a/src/Global.cpp
+++ b/src/Global.cpp
@@ -1,5 +1,5 @@
 /*****************************************************
-* TP IFT3100H25 - Adventure Party Maker
+ * TP IFT3100H25 - Adventure Party Maker
  * by Team 12
  *****************************************************
  *
@@ -9,7 +9,7 @@
 #include "Global.h"
 #include <Level.h>
 
-// Static allocation
+ // Static allocation
 std::array<Camera, 3> Global::m_cameras;
 int Global::m_countNodeRender[3];
 Skybox Global::m_skybox;
@@ -20,6 +20,7 @@ ActionManager Global::m_actions;
 bool Global::m_selectedFromViewport = false;
 TooltipMessages Global::m_tooltipMessages;
 CursorManager Global::m_cursorManager;
+ModelManager Global::m_modelManager;
 float Global::m_sequenceInterval = 0.5;
 int Global::m_sequenceCount = -1;
 std::string Global::m_sequenceName = "";
@@ -30,12 +31,18 @@ float Global::m_sequenceTotalDelta = 0;
  */
 void Global::setup() {
 
+	//Load models (characters and assets)
+	m_modelManager.init();
 
+	//Setup camera positions
 	m_cameras[0].setup(ofVec3f(0, 600, 2100), ofVec3f(0, 400, 0));
 	m_cameras[1].setup(ofVec3f(0, 3000, 0), ofVec3f(0, 0, 0));
 	m_cameras[2].setup(ofVec3f(2400, 300, 200), ofVec3f(0, 300, 200));
 
+	//Init scene
 	m_level.reset();
+
+	//Setup cursors
 	m_cursorManager.setup();
 
 }

--- a/src/Global.h
+++ b/src/Global.h
@@ -1,5 +1,5 @@
 /*****************************************************
-* TP IFT3100H25 - Adventure Party Maker
+ * TP IFT3100H25 - Adventure Party Maker
  * by Team 12
  *****************************************************
  *
@@ -17,6 +17,7 @@
 #include "TooltipMessages.hpp"
 #include "Skybox.h"
 #include "CursorManager.h"
+#include "ModelManager.h"
 
 class Global {
 
@@ -25,9 +26,9 @@ public:
 	static std::array<Camera, 3> m_cameras;
 	static int m_countNodeRender[3];
 
-    // Sequence recording
-    static std::string m_sequenceName;
-    static float m_sequenceTotalDelta;
+	// Sequence recording
+	static std::string m_sequenceName;
+	static float m_sequenceTotalDelta;
 	static float m_sequenceInterval;
 	static int m_sequenceCount;
 
@@ -41,7 +42,7 @@ public:
 	static ofColor idToColor(int id);
 	static int colorToId(ofColor color);
 	static CursorManager m_cursorManager;
-
+	static ModelManager m_modelManager;
 	static TooltipMessages m_tooltipMessages;
 
 };

--- a/src/Level.cpp
+++ b/src/Level.cpp
@@ -1,5 +1,5 @@
 /*****************************************************
-* TP IFT3100H25 - Adventure Party Maker
+ * TP IFT3100H25 - Adventure Party Maker
  * by Team 12
  *****************************************************
  *
@@ -15,6 +15,8 @@
 
 #include "SphereNode.h"
 #include "ModelNode.h"
+#include "AssetNode.h"
+#include "CharacterNode.h"
 #include "CylinderNode.h"
 #include "ConeNode.h"
 #include "XmlHandler.h"
@@ -138,34 +140,47 @@ void Level::reset() {
 	//--- Group of 5 adventurers. 
 	// The user can add the knight via the "Add Node" button (it's more insteresting to use if they are not addding a duplicate)
 	GroupNode* adventurer_group = new GroupNode("Adventurers");
-	adventurer_group->getTransform().setOrientation(glm::vec3(0, 0, 0));
+	//adventurer_group->getTransform().setOrientation(glm::vec3(0, 0, 0));
 	m_tree->addChild(adventurer_group);
 
-	ModelNode* node_rogue = new ModelNode("Rogue", "Kaykit/Characters/gltf/Rogue.glb");
+	CharacterNode* node_rogue = new CharacterNode("Rogue", "Rogue");
 	adventurer_group->addChild(node_rogue);
-	node_rogue->setProperty("Animation", 11);
+	node_rogue->setProperty("Animation", 6);
 
-	ModelNode* node_barbarian = new ModelNode("Barbarian", "Kaykit/Characters/gltf/Barbarian.glb");
+	CharacterNode* node_barbarian = new CharacterNode("Barbarian", "Barbarian");
 	adventurer_group->addChild(node_barbarian);
 	node_barbarian->setPosition(-600, 0, 75);
-	node_barbarian->getTransform().setOrientation(glm::vec3(0,25,0));
+	node_barbarian->getTransform().setOrientation(glm::vec3(0, 25, 0));
 
-	ModelNode* node_mage = new ModelNode("Mage", "Kaykit/Characters/gltf/Mage.glb");
+	CharacterNode* node_mage = new CharacterNode("Mage", "Mage");
 	adventurer_group->addChild(node_mage);
 	node_mage->setPosition(-1200, 0, 200);
 	node_mage->getTransform().setOrientation(glm::vec3(0, 45, 0));
-	node_mage->setProperty("Animation", 13);
+	node_mage->setProperty("Animation", 7);
 
-	ModelNode* node_engineer = new ModelNode("Engineer", "Kaykit/Characters/gltf/Engineer.glb");
+	CharacterNode* node_engineer = new CharacterNode("Engineer", "Engineer");
 	adventurer_group->addChild(node_engineer);
 	node_engineer->setPosition(600, 0, 75);
 	node_engineer->getTransform().setOrientation(glm::vec3(0, -25, 0));
 
-	ModelNode* node_druid = new ModelNode("Druid", "Kaykit/Characters/gltf/Druid.glb");
+	CharacterNode* node_druid = new CharacterNode("Druid", "Druid");
 	adventurer_group->addChild(node_druid);
 	node_druid->setPosition(1200, 0, 200);
 	node_druid->getTransform().setOrientation(glm::vec3(0, -45, 0));
 	node_druid->setProperty("Animation", 0);
+
+	//--- Some assets
+	GroupNode* loot_group = new GroupNode("Loot");
+	m_tree->addChild(loot_group);
+
+	AssetNode* chest_node = new AssetNode("Crate", "ammo_crate_withLid");
+	loot_group->addChild(chest_node);
+	chest_node->setPosition(-600, 0, -700);
+	chest_node->getTransform().setOrientation(glm::vec3(0, 5, 0));
+
+	AssetNode* potion_node = new AssetNode("Large blue potion", "potion_large_blue");
+	loot_group->addChild(potion_node);
+	potion_node->setPosition(1100, 425, -700);
 
 	//--- A pine tree made of primitives
 	GroupNode* tree_group = new GroupNode("Pine Tree");
@@ -174,12 +189,12 @@ void Level::reset() {
 
 	CylinderNode* node_cylinder = new CylinderNode("Trunk");
 	tree_group->addChild(node_cylinder);
-	node_cylinder->getTransform().setScale(3,4,3);
+	node_cylinder->getTransform().setScale(3, 4, 3);
 	node_cylinder->setProperty("Diffuse Color", ofFloatColor(0.5, 0.31, 0.07));
 
 	ConeNode* node_cone = new ConeNode("Foliage");
 	tree_group->addChild(node_cone);
-	node_cone->getTransform().rotateDeg(180.0,glm::vec3(0,0,1));
+	node_cone->getTransform().rotateDeg(180.0, glm::vec3(0, 0, 1));
 	node_cone->getTransform().setPosition(0, 600, 0);
 	node_cone->getTransform().setScale(10, 7, 10);
 	node_cone->setProperty("Diffuse Color", ofFloatColor(0.08, 0.28, 0.20));
@@ -210,7 +225,7 @@ void Level::reset() {
 	int sphere_count = 1;
 	float sphere_spacing = 320.0f;
 	for (int z = 0; z < 1; z++) {
-	    test_spawn_sphere(node, sphere_count, sphere_spacing, z * sphere_spacing, 0);
+		test_spawn_sphere(node, sphere_count, sphere_spacing, z * sphere_spacing, 0);
 	}
 	node->setDisplayNode(false);
 

--- a/src/nodes/AssetNode.cpp
+++ b/src/nodes/AssetNode.cpp
@@ -1,0 +1,18 @@
+/*****************************************************
+ * TP IFT3100H25 - Adventure Party Maker
+ * by Team 12
+ *****************************************************
+ *
+ * ModelNode class implementation
+ *
+ *****************************************************/
+#include "AssetNode.h"
+
+
+AssetNode::AssetNode(const std::string& p_name, const std::string& p_fileBaseName) 
+	: ModelNode(
+		p_name,
+		((p_fileBaseName != "") ? p_fileBaseName : Global::m_modelManager.getRandom(MODEL_TYPE::ASSET)),
+		MODEL_TYPE::ASSET)
+{
+}

--- a/src/nodes/AssetNode.h
+++ b/src/nodes/AssetNode.h
@@ -1,0 +1,19 @@
+/*****************************************************
+ * TP IFT3100H25 - Adventure Party Maker
+ * by Team 12
+ *****************************************************
+ *
+ * ModelNode class implementation
+ *
+ *****************************************************/
+#pragma once
+#include "ModelNode.h"
+#include "Global.h"
+
+class AssetNode :
+    public ModelNode
+{
+public:
+    AssetNode(const std::string& p_name = "New asset", const std::string& p_fileBaseName = "");
+};
+

--- a/src/nodes/CharacterNode.cpp
+++ b/src/nodes/CharacterNode.cpp
@@ -1,0 +1,345 @@
+/*****************************************************
+ * TP IFT3100H25 - Adventure Party Maker
+ * by Team 12
+ *****************************************************
+ *
+ * ModelNode class implementation
+ *
+ *****************************************************/
+#include "CharacterNode.h"
+
+CharacterNode::CharacterNode(const std::string& p_name, const std::string& p_fileBaseName) 
+	: ModelNode(p_name,
+		((p_fileBaseName != "") ? p_fileBaseName : Global::m_modelManager.getRandom(MODEL_TYPE::CHARACTER)),
+		MODEL_TYPE::CHARACTER
+	)
+{
+	initHardcodedList();
+	initAnimationsList();
+	getModel().setLoopStateForAllAnimations(OF_LOOP_NORMAL);
+	setCurrentAnimation(getCurrentAnimationID());
+
+	//debugPrintNames();
+}
+
+
+int CharacterNode::draw(bool p_objectPicking, Camera* p_camera)
+{
+	if (!getDisplayNode()) return 0; //nothing to draw if the user hid the node
+
+	int count = 0;
+	beginDraw(p_objectPicking);
+	updateBoundingBox();
+
+	if (p_camera->testVisibility(m_transform.getGlobalPosition(), getBoundingBox())) {
+		if (m_playAnimation)
+		{
+			getModel().update();
+		}
+		m_transform.transformGL();
+		if (p_objectPicking) {
+			getModel().disableMaterials();
+			getModel().disableNormals();
+			getModel().disableTextures();
+		}
+
+		getModel().drawFaces();
+
+		if (p_objectPicking) {
+			getModel().enableMaterials();
+			getModel().enableNormals();
+			getModel().enableTextures();
+		}
+
+		m_transform.restoreTransformGL();
+		count++;
+	}
+
+	count += endDraw(p_objectPicking, p_camera);
+	return count;
+}
+
+
+/**
+ * Get ModelNode's properties list
+ */
+std::vector<NodeProperty> CharacterNode::getProperties() const
+{
+	std::vector<NodeProperty> properties = ModelNode::getProperties();
+
+	properties.emplace_back("Animation parameters", PROPERTY_TYPE::LABEL, nullptr);
+	properties.emplace_back("Play", PROPERTY_TYPE::BOOLEAN_FIELD, m_playAnimation, Global::m_tooltipMessages.node_playAnimation);
+	properties.emplace_back("Animation", PROPERTY_TYPE::ITEM_LIST, (m_showAllAnimations) ? m_animNamesFull : m_animNamesRestricted);
+	properties.emplace_back("Show all", PROPERTY_TYPE::BOOLEAN_FIELD, m_showAllAnimations, Global::m_tooltipMessages.node_showAllAnimation);
+
+	return properties;
+}
+
+
+/**
+ * A user changed a property
+ */
+void CharacterNode::setProperty(const std::string& p_name, std::any p_value)
+{
+	if (p_name == "Play") {
+		m_playAnimation = std::any_cast<bool>(p_value);
+		return;
+	}
+	if (p_name == "Animation") {
+		if (m_showAllAnimations)
+		{
+			setCurrentAnimation(std::any_cast<int>(p_value));
+		}
+		else
+		{
+			setCurrentAnimation(getAnimFromRestricted(std::any_cast<int>(p_value)));
+		}
+		return;
+	}
+	if (p_name == "Show all") {
+		m_showAllAnimations = std::any_cast<bool>(p_value);
+		return;
+	}
+
+	ModelNode::setProperty(p_name, p_value);
+
+	if (p_name == "Model") {
+		resetAnimation();
+		return;
+	}
+}
+
+
+/**
+ * Prepare animations for use
+ */
+void CharacterNode::initAnimationsList()
+{
+	bool addAnimation = true;
+	std::string animName;
+	for (unsigned int i = 0; i < getModel().getAnimationCount(); i++, addAnimation = true)
+	{
+		for (auto anim : m_animations)
+		{
+			if (anim->m_devName == getModel().getAnimation(i).getAnimation()->mName.data)
+			{
+				addAnimation = false;
+				break;
+			}
+		}
+		if (addAnimation)
+		{
+			animName = getModel().getAnimation(i).getAnimation()->mName.data;
+			AnimationData* animData = new AnimationData(i, animName, makePlayerFacingName(animName));
+			m_animations.push_back(animData);
+		}
+	}
+	m_currentAnimID = getAnimFromRestricted(stoi(m_animNamesRestricted.back()));
+
+}
+
+
+/**
+ * I hate this so much (hardcoded names)
+ */
+void CharacterNode::initHardcodedList()
+{
+	// Partial list
+	m_animNamesRestricted.push_back(makePlayerFacingName("2H_Melee_Idle"));
+	m_animNamesRestricted.push_back(makePlayerFacingName("Death_A_Pose"));
+	m_animNamesRestricted.push_back(makePlayerFacingName("Idle"));
+	m_animNamesRestricted.push_back(makePlayerFacingName("Jump_Idle"));
+	m_animNamesRestricted.push_back(makePlayerFacingName("Lie_Idle"));
+	m_animNamesRestricted.push_back(makePlayerFacingName("Running_A"));
+	m_animNamesRestricted.push_back(makePlayerFacingName("Sit_Floor_Idle"));
+	m_animNamesRestricted.push_back(makePlayerFacingName("Spellcasting"));
+	m_animNamesRestricted.push_back(makePlayerFacingName("Unarmed_Idle"));
+	m_animNamesRestricted.push_back(makePlayerFacingName("Walking_Backwards"));
+	m_animNamesRestricted.push_back(m_DEFAULT_RESTRICTED_ANIM);
+	//Recording the position at the back makes it easier to deal with this list everywhere
+
+	// Full list
+	m_animNamesFull.push_back(makePlayerFacingName("1H_Melee_Attack_Chop"));
+	m_animNamesFull.push_back(makePlayerFacingName("1H_Melee_Attack_Slice_Diagonal"));
+	m_animNamesFull.push_back(makePlayerFacingName("1H_Melee_Attack_Slice_Horizontal"));
+	m_animNamesFull.push_back(makePlayerFacingName("1H_Melee_Attack_Stab"));
+	m_animNamesFull.push_back(makePlayerFacingName("1H_Ranged_Aiming"));
+	m_animNamesFull.push_back(makePlayerFacingName("1H_Ranged_Reload"));
+	m_animNamesFull.push_back(makePlayerFacingName("1H_Ranged_Shoot"));
+	m_animNamesFull.push_back(makePlayerFacingName("1H_Ranged_Shooting"));
+	m_animNamesFull.push_back(makePlayerFacingName("2H_Melee_Attack_Chop"));
+	m_animNamesFull.push_back(makePlayerFacingName("2H_Melee_Attack_Slice"));
+	m_animNamesFull.push_back(makePlayerFacingName("2H_Melee_Attack_Spin"));
+	m_animNamesFull.push_back(makePlayerFacingName("2H_Melee_Attack_Spinning"));
+	m_animNamesFull.push_back(makePlayerFacingName("2H_Melee_Attack_Stab"));
+	m_animNamesFull.push_back(makePlayerFacingName("2H_Melee_Idle"));
+	m_animNamesFull.push_back(makePlayerFacingName("2H_Ranged_Aiming"));
+	m_animNamesFull.push_back(makePlayerFacingName("2H_Ranged_Reload"));
+	m_animNamesFull.push_back(makePlayerFacingName("2H_Ranged_Shoot"));
+	m_animNamesFull.push_back(makePlayerFacingName("2H_Ranged_Shooting"));
+	m_animNamesFull.push_back(makePlayerFacingName("Block"));
+	m_animNamesFull.push_back(makePlayerFacingName("Block_Attack"));
+	m_animNamesFull.push_back(makePlayerFacingName("Block_Hit"));
+	m_animNamesFull.push_back(makePlayerFacingName("Blocking"));
+	m_animNamesFull.push_back(makePlayerFacingName("Cheer"));
+	m_animNamesFull.push_back(makePlayerFacingName("Death_A"));
+	m_animNamesFull.push_back(makePlayerFacingName("Death_A_Pose"));
+	m_animNamesFull.push_back(makePlayerFacingName("Death_B"));
+	m_animNamesFull.push_back(makePlayerFacingName("Death_B_Pose"));
+	m_animNamesFull.push_back(makePlayerFacingName("Dodge_Backward"));
+	m_animNamesFull.push_back(makePlayerFacingName("Dodge_Forward"));
+	m_animNamesFull.push_back(makePlayerFacingName("Dodge_Left"));
+	m_animNamesFull.push_back(makePlayerFacingName("Dodge_Right"));
+	m_animNamesFull.push_back(makePlayerFacingName("Dualwield_Melee_Attack_Chop"));
+	m_animNamesFull.push_back(makePlayerFacingName("Dualwield_Melee_Attack_Slice"));
+	m_animNamesFull.push_back(makePlayerFacingName("Dualwield_Melee_Attack_Stab"));
+	m_animNamesFull.push_back(makePlayerFacingName("Hit_A"));
+	m_animNamesFull.push_back(makePlayerFacingName("Hit_B"));
+	m_animNamesFull.push_back(makePlayerFacingName("Idle"));
+	m_animNamesFull.push_back(makePlayerFacingName("Interact"));
+	m_animNamesFull.push_back(makePlayerFacingName("Jump_Full_Long"));
+	m_animNamesFull.push_back(makePlayerFacingName("Jump_Full_Short"));
+	m_animNamesFull.push_back(makePlayerFacingName("Jump_Idle"));
+	m_animNamesFull.push_back(makePlayerFacingName("Jump_Land"));
+	m_animNamesFull.push_back(makePlayerFacingName("Jump_Start"));
+	m_animNamesFull.push_back(makePlayerFacingName("Lie_Down"));
+	m_animNamesFull.push_back(makePlayerFacingName("Lie_Idle"));
+	m_animNamesFull.push_back(makePlayerFacingName("Lie_Pose"));
+	m_animNamesFull.push_back(makePlayerFacingName("Lie_StandUp"));
+	m_animNamesFull.push_back(makePlayerFacingName("PickUp"));
+	m_animNamesFull.push_back(makePlayerFacingName("Running_A"));
+	m_animNamesFull.push_back(makePlayerFacingName("Running_B"));
+	m_animNamesFull.push_back(makePlayerFacingName("Running_Strafe_Left"));
+	m_animNamesFull.push_back(makePlayerFacingName("Running_Strafe_Right"));
+	m_animNamesFull.push_back(makePlayerFacingName("Sit_Chair_Down"));
+	m_animNamesFull.push_back(makePlayerFacingName("Sit_Chair_Idle"));
+	m_animNamesFull.push_back(makePlayerFacingName("Sit_Chair_Pose"));
+	m_animNamesFull.push_back(makePlayerFacingName("Sit_Chair_StandUp"));
+	m_animNamesFull.push_back(makePlayerFacingName("Sit_Floor_Down"));
+	m_animNamesFull.push_back(makePlayerFacingName("Sit_Floor_Idle"));
+	m_animNamesFull.push_back(makePlayerFacingName("Sit_Floor_Pose"));
+	m_animNamesFull.push_back(makePlayerFacingName("Sit_Floor_StandUp"));
+	m_animNamesFull.push_back(makePlayerFacingName("Spellcast_Long"));
+	m_animNamesFull.push_back(makePlayerFacingName("Spellcast_Raise"));
+	m_animNamesFull.push_back(makePlayerFacingName("Spellcast_Shoot"));
+	m_animNamesFull.push_back(makePlayerFacingName("Spellcasting"));
+	m_animNamesFull.push_back(makePlayerFacingName("T-Pose"));
+	m_animNamesFull.push_back(makePlayerFacingName("Throw"));
+	m_animNamesFull.push_back(makePlayerFacingName("Unarmed_Idle"));
+	m_animNamesFull.push_back(makePlayerFacingName("Unarmed_Melee_Attack_Kick"));
+	m_animNamesFull.push_back(makePlayerFacingName("Unarmed_Melee_Attack_Punch_A"));
+	m_animNamesFull.push_back(makePlayerFacingName("Unarmed_Melee_Attack_Punch_B"));
+	m_animNamesFull.push_back(makePlayerFacingName("Unarmed_Pose"));
+	m_animNamesFull.push_back(makePlayerFacingName("Use_Item"));
+	m_animNamesFull.push_back(makePlayerFacingName("Walking_A"));
+	m_animNamesFull.push_back(makePlayerFacingName("Walking_B"));
+	m_animNamesFull.push_back(makePlayerFacingName("Walking_Backwards"));
+	m_animNamesFull.push_back(makePlayerFacingName("Walking_C"));
+	m_animNamesFull.push_back(m_DEFAULT_FULL_ANIM);
+
+}
+
+
+/**
+ * From an index in the restricted list, find the actual animation in the full list
+ */
+int CharacterNode::getAnimFromRestricted(int p_index)
+{
+	std::string nameToFind = m_animNamesRestricted.at(p_index);
+	for (auto anim : m_animations)
+	{
+		if (anim->m_playerFacingName == nameToFind)
+		{
+			return anim->m_animationID;
+		}
+	}
+	return -1;
+}
+
+
+/**
+ * From a name, find the anim's index in the limited list and record it
+ */
+void CharacterNode::setAnimInRestricted(int p_index)
+{
+	std::string nameToFind = m_animations.at(p_index)->m_playerFacingName;
+	bool isFound = false;
+	for (size_t i = 0; i < m_animNamesRestricted.size(); i++)
+	{
+		if (m_animNamesRestricted.at(i) == nameToFind)
+		{
+			m_animNamesRestricted.back() = std::to_string(i);
+			isFound = true;
+			break;
+		}
+	}
+	if (!isFound) {
+		m_animNamesRestricted.back() = m_DEFAULT_RESTRICTED_ANIM;
+	}
+
+}
+
+
+/**
+ * Get pointer to the current animation
+ */
+AnimationData* CharacterNode::getCurrentAnimation() const
+{
+	return m_animations.at(m_currentAnimID);
+}
+
+
+/**
+ * Get the current animation ID
+ */
+int CharacterNode::getCurrentAnimationID() const
+{
+	return m_currentAnimID;
+}
+
+
+/**
+ * Update the current animation
+ */
+void CharacterNode::setCurrentAnimation(int p_ID)
+{
+		stopCurrentAnimation();
+		m_currentAnimID = p_ID;
+		m_animNamesFull.back() = std::to_string(p_ID);
+		setAnimInRestricted(p_ID);
+		getModel().getAnimation(m_animations.at(getCurrentAnimationID())->m_animationID).play();
+}
+
+
+void CharacterNode::stopCurrentAnimation()
+{
+	getModel().getAnimation(m_animations.at(m_currentAnimID)->m_animationID).stop();
+}
+
+
+void CharacterNode::resetAnimation()
+{
+	stopCurrentAnimation();
+	getModel().setLoopStateForAllAnimations(OF_LOOP_NORMAL);
+	setCurrentAnimation(m_currentAnimID);
+}
+
+
+/**
+ * Get the animation's name
+ */
+std::string CharacterNode::getCurrentAnimationName() const
+{
+	return getCurrentAnimation()->m_playerFacingName;
+}
+
+
+void CharacterNode::debugPrintNames() const
+{
+	ofLog() << "----------------------------";
+	ofLog() << "- Printing names for [" << m_name << "]";
+	for (auto anim : m_animations)
+	{
+		ofLog() << " --- Anim: " << anim->m_animationID << " : " << anim->m_devName << " (Player facing name: " << anim->m_playerFacingName << ")";
+	}
+}

--- a/src/nodes/CharacterNode.h
+++ b/src/nodes/CharacterNode.h
@@ -1,0 +1,58 @@
+/*****************************************************
+ * TP IFT3100H25 - Adventure Party Maker
+ * by Team 12
+ *****************************************************
+ *
+ * ModelNode class implementation
+ *
+ *****************************************************/
+#pragma once
+#include "ModelNode.h"
+#include "ofMain.h"
+#include "ofxCustomAssimpModelLoader.h"
+#include "Global.h"
+#include <vector>
+
+struct AnimationData
+{
+	AnimationData(int p_id, const std::string& p_dName, const std::string& p_pName) 
+		: m_animationID(p_id), m_devName(p_dName), m_playerFacingName(p_pName) {}
+	int m_animationID;
+	std::string m_devName;
+	std::string m_playerFacingName;
+};
+
+class CharacterNode : public ModelNode
+{
+private:
+	bool m_playAnimation = true;
+	bool m_showAllAnimations = false;
+	const std::string m_DEFAULT_RESTRICTED_ANIM = "2";  // the number here means "Idle", which is 36 in the full list
+	const std::string m_DEFAULT_FULL_ANIM = "36";
+	std::vector<AnimationData*> m_animations;
+	std::vector<std::string> m_animNamesRestricted; // used for showing them to the user
+	std::vector<std::string> m_animNamesFull;
+	int m_currentAnimID;
+	
+public:
+	CharacterNode(const std::string& p_name = "New Character", const std::string& p_fileBaseName = "");
+	int draw(bool p_objectPicking, Camera* p_camera) override;
+
+	std::vector<NodeProperty> getProperties() const override;
+	void setProperty(const std::string& p_name, std::any p_value) override;
+
+	void setCurrentAnimation(int p_ID);
+	std::string getCurrentAnimationName() const;
+
+private:
+	void initHardcodedList();
+	void initAnimationsList();
+	AnimationData* getCurrentAnimation() const;
+	void stopCurrentAnimation();
+	void resetAnimation();
+	int getCurrentAnimationID() const;
+	int getAnimFromRestricted(int p_index);
+	void setAnimInRestricted(int p_index);
+	void debugPrintNames() const;
+};
+

--- a/src/nodes/ModelManager.cpp
+++ b/src/nodes/ModelManager.cpp
@@ -1,0 +1,173 @@
+/*****************************************************
+ * TP IFT3100H25 - Adventure Party Maker
+ * by Team 12
+ *****************************************************
+ *
+ * ModelManager class definition
+ *
+ *****************************************************/
+#include "ModelManager.h"
+
+/**
+* Call this to load the models and list their names
+*/
+void ModelManager::init()
+{
+	listNames(m_characterStrNames, m_charactersPath, m_charactersExtension);
+	listNames(m_assetStrNames, m_assetsPath, m_assetsExtension);
+	listCNames(m_characterStrNames, m_characterCNames);
+	listCNames(m_assetStrNames, m_assetCNames);
+}
+
+
+/**
+* Lists file names with a given extension from a given folder
+*/
+//std::vector<char*>& p_cList
+void ModelManager::listNames(std::vector<std::string>& p_list, const std::string& p_directoryPath, const std::string& p_fileExtension)
+{
+	if( ! ofDirectory::doesDirectoryExist(p_directoryPath)) {
+		ofLog(OF_LOG_FATAL_ERROR) << "This directory does not exist: " << p_directoryPath;
+	}
+
+	ofDirectory directory;
+	directory.open(p_directoryPath);
+	std::vector<ofFile> files = directory.getFiles();
+	std::string fileBaseName;
+	for (ofFile file : files) {
+		if (file.getExtension() == p_fileExtension) {
+			fileBaseName = file.getBaseName();
+			p_list.push_back(fileBaseName.c_str());
+		}
+	}
+	directory.close();
+}
+
+
+/**
+* List the keys in a vector; needed for NodeProperties and ImGui
+*/
+void ModelManager::listCNames(std::vector<std::string>& p_list, std::vector<char*>& p_cList)
+{
+	p_cList.reserve(p_list.size());
+	for (const auto& item : p_list) {
+		p_cList.push_back(const_cast<char*>(item.c_str()));
+	}
+
+}
+
+
+/**
+* Gets the names list. Use with ImGui Combo
+*/
+const std::vector<char*> ModelManager::getCNames(MODEL_TYPE p_type)
+{
+	if (p_type == MODEL_TYPE::ASSET) {
+		return m_assetCNames;
+	}
+	if (p_type == MODEL_TYPE::CHARACTER) {
+		return m_characterCNames;
+	}
+	ofLog(OF_LOG_FATAL_ERROR) << "Unrecognised MODEL_TYPE.";
+}
+
+
+/**
+* Constructs and returns the model's file path
+* in: model's file base name (i.e.: "barbarian")
+*/
+std::string ModelManager::getModelPath(const std::string& p_name, MODEL_TYPE p_type)
+{
+	if (p_type == MODEL_TYPE::ASSET) {
+		return 	m_assetsPath + "/" + p_name + "." + m_assetsExtension;
+	}
+	else if (p_type == MODEL_TYPE::CHARACTER) {
+		return m_charactersPath + "/" + p_name + "." + m_charactersExtension;
+	}
+	else {
+		ofLog(OF_LOG_FATAL_ERROR) << "Unrecognised MODEL_TYPE.";
+	}
+}
+
+
+/**
+* Constructs and returns the model's file path.
+* Typically use this one after the user changed the model's type via the NodeProperty
+* in: model's index in the c names list (i.e.: 0)
+*/
+std::string ModelManager::getModelPath(int p_cIndex, MODEL_TYPE p_type)
+{
+	if (p_type == MODEL_TYPE::ASSET) {
+		std::string sName(m_assetCNames.at(p_cIndex));
+		return getModelPath(sName, p_type);
+	}
+	else if (p_type == MODEL_TYPE::CHARACTER) {
+		std::string sName(m_characterCNames.at(p_cIndex));
+		return getModelPath(sName, p_type);
+	}
+	else {
+		ofLog(OF_LOG_FATAL_ERROR) << "Unrecognised MODEL_TYPE.";
+	}
+}
+
+
+/**
+* p_index is an index in the cnames list
+*/
+std::string ModelManager::getModelName(int p_index, MODEL_TYPE p_type)
+{
+	if (p_type == MODEL_TYPE::ASSET) {
+		return std::string(m_assetCNames[p_index]);
+	}
+	else if (p_type == MODEL_TYPE::CHARACTER) {
+		return std::string(m_characterCNames[p_index]);
+	}
+	else {
+		ofLog(OF_LOG_FATAL_ERROR) << "Unrecognised MODEL_TYPE.";
+	}
+}
+
+
+/**
+* Gets a random model of type
+*/
+std::string ModelManager::getRandom(MODEL_TYPE p_type)
+{
+	if (p_type == MODEL_TYPE::ASSET) {
+		return std::string(m_assetCNames[(rand() % m_assetCNames.size())]);
+	}
+	else if (p_type == MODEL_TYPE::CHARACTER) {
+		return std::string(m_characterCNames[(rand() % m_characterCNames.size())]);
+	}
+	else {
+		ofLog(OF_LOG_FATAL_ERROR) << "Unrecognised MODEL_TYPE.";
+	}
+}
+
+
+/**
+* Gets the model's index in the C names list (necessary for NodeProperty and ImGui's combo)
+*/
+int ModelManager::getModelNo(const std::string& p_name, MODEL_TYPE p_type)
+{
+	//std::string name;
+	if (p_type == MODEL_TYPE::ASSET) {
+		for (int i = 0; i < m_assetCNames.size(); i++) {
+			std::string name(m_assetCNames[i]);
+			if (name == p_name) {
+				return i;
+			}
+		};
+	}
+	else if (p_type == MODEL_TYPE::CHARACTER) {
+		for (int i = 0; i < m_characterCNames.size(); i++) {
+			std::string name(m_characterCNames[i]);
+			if (name == p_name) {
+				return i;
+			}
+		};
+	}
+	else {
+		ofLog(OF_LOG_FATAL_ERROR) << "Unrecognised MODEL_TYPE.";
+	}
+}

--- a/src/nodes/ModelManager.h
+++ b/src/nodes/ModelManager.h
@@ -1,0 +1,59 @@
+/*****************************************************
+ * TP IFT3100H25 - Adventure Party Maker
+ * by Team 12
+ *****************************************************
+ *
+ * ModelManager class definition
+ *
+ *****************************************************/
+#pragma once
+#include <vector>
+#include <string>
+#include <ofxXmlSettings.h>
+//#include <memory>
+//#include <sstream>
+#include "ofMain.h"
+#include "ofxCustomAssimpModelLoader.h"
+
+
+enum class MODEL_TYPE {
+	ASSET,
+	CHARACTER
+};
+
+
+/**
+* In this application, the word "model" is the broadest term.
+* We have two types of models:
+* - characters: these are the rogue, knight, etc. They have animations;
+* - assets: decoration items. They are detached from characters and do not have animations in this application.
+*/
+class ModelManager
+{
+	//variables
+private:
+	const std::string m_charactersPath = "KayKit/Characters/gltf";
+	const std::string m_assetsPath = "KayKit/Assets/gltf";
+	const std::string m_animPath = "KayKit/Characters/gltf/Animations.xml";
+	const std::string m_charactersExtension = "glb";
+	const std::string m_assetsExtension = "gltf";
+	std::vector<std::string> m_characterStrNames;
+	std::vector<std::string> m_assetStrNames;
+	std::vector<char*> m_characterCNames;
+	std::vector<char*> m_assetCNames;
+	
+	//functions
+public: 
+	void init();
+private:
+	void listNames(std::vector<std::string>& p_list, const std::string& p_directoryPath, const std::string& p_fileExtension);
+	void listCNames(std::vector<std::string>& p_list, std::vector<char*>& p_cList);
+public:
+	const std::vector<char*> getCNames(MODEL_TYPE p_type);
+	std::string getModelPath(const std::string& p_name, MODEL_TYPE p_type);
+	std::string getModelPath(int p_cIndex, MODEL_TYPE p_type);
+	std::string getModelName(int p_index, MODEL_TYPE p_type);
+	std::string getRandom(MODEL_TYPE p_type);
+	int getModelNo(const std::string& p_name, MODEL_TYPE p_type);
+};
+

--- a/src/nodes/ModelNode.cpp
+++ b/src/nodes/ModelNode.cpp
@@ -11,21 +11,73 @@
 
  /**
   * Constructor
+  * in:
+  * p_nodeName: the name of the node, for example "Barbarian"
+  * p_fileBaseName: the base name of the model's file, for example "Barbarian".
+  * The path will be constructed by the ModelManager from p_fileBaseName
   */
-ModelNode::ModelNode(const std::string& p_name, const std::string& p_filePath) : BaseNode(p_name) {
-	// 1 - load the model
-	m_model.loadModel(p_filePath);
+ModelNode::ModelNode(const std::string& p_nodeName, const std::string& p_fileBaseName, MODEL_TYPE p_modelType)
+	: BaseNode(p_nodeName), m_modelType(p_modelType)
+{
+	updateModel(p_fileBaseName);
+}
+
+
+/**
+ * Update data on initialization or after a user changed a property
+ */
+void ModelNode::updateModel(int p_modelNo) {
+	m_modelNo = p_modelNo;
+	m_fileBaseName = Global::m_modelManager.getModelName(p_modelNo, m_modelType);
+	loadModel(Global::m_modelManager.getModelPath(p_modelNo, m_modelType));
+}
+void ModelNode::updateModel(const std::string& p_modelName) {
+	m_modelNo = Global::m_modelManager.getModelNo(p_modelName, m_modelType);
+	m_fileBaseName = p_modelName;
+	loadModel(Global::m_modelManager.getModelPath(p_modelName, m_modelType));
+}
+void ModelNode::loadModel(const std::string& p_filePath) {
+	//m_filePath = p_filePath;
+	m_model.load(p_filePath);
 	m_model.setRotation(0, 180, 1, 0, 0);
+}
 
-	// 2- setup animations
-	initHardcodedList();
-	initAnimationsList();
-	setLoopingState(true);
-	m_previousAnimID = 0;
-	setCurrentAnimation(getCurrentAnimationID());
 
-	//debugPrintNames();
-	
+/**
+ * Get ModelNode's properties list
+ */
+std::vector<NodeProperty> ModelNode::getProperties() const
+{
+	std::vector<NodeProperty> properties;
+	//base properties
+	properties.emplace_back("Name", PROPERTY_TYPE::TEXT_FIELD, m_name);
+	properties.emplace_back("Display", PROPERTY_TYPE::BOOLEAN_FIELD, m_displayNode, Global::m_tooltipMessages.node_display);
+	properties.emplace_back("Transform", PROPERTY_TYPE::LABEL, nullptr);
+	properties.emplace_back("Position", PROPERTY_TYPE::VECTOR3, m_transform.getPosition());
+	properties.emplace_back("Orientation", PROPERTY_TYPE::VECTOR3, m_transform.getOrientationEulerDeg());
+	properties.emplace_back("Scale", PROPERTY_TYPE::VECTOR3, m_transform.getScale());
+
+	//no material property for models
+
+	//model property
+	properties.emplace_back("Model parameter", PROPERTY_TYPE::LABEL, nullptr);
+	properties.emplace_back("Model", PROPERTY_TYPE::MODEL_LIST, std::make_pair(m_modelNo, m_modelType), Global::m_tooltipMessages.node_model);
+
+	return properties;
+}
+
+
+/**
+ * A user changed a property
+ */
+void ModelNode::setProperty(const std::string& p_name, std::any p_value)
+{
+	if (p_name == "Model") {
+		m_model.clear();
+		updateModel(std::any_cast<int>(p_value));
+		return;
+	}
+	BaseNode::setProperty(p_name, p_value);
 }
 
 
@@ -57,10 +109,6 @@ int ModelNode::draw(bool p_objectPicking, Camera* p_camera)
 
 	if (p_camera->testVisibility(m_transform.getGlobalPosition(), getBoundingBox())) {
 		m_transform.transformGL();
-		if (m_playAnimation)
-		{
-			m_model.update();
-		}
 		if (p_objectPicking) {
 			m_model.disableMaterials();
 			m_model.disableNormals();
@@ -134,319 +182,11 @@ void ModelNode::drawBoundingBox() {
 
 
 /**
- * Get ModelNode's properties list
- */
-std::vector<NodeProperty> ModelNode::getProperties() const
-{
-
-	std::vector<NodeProperty> properties;
-	properties.emplace_back("Name", PROPERTY_TYPE::TEXT_FIELD, m_name);
-	properties.emplace_back("Display", PROPERTY_TYPE::BOOLEAN_FIELD, m_displayNode, Global::m_tooltipMessages.node_display);
-	properties.emplace_back("Transform", PROPERTY_TYPE::LABEL, nullptr);
-	properties.emplace_back("Position", PROPERTY_TYPE::VECTOR3, m_transform.getPosition());
-	properties.emplace_back("Orientation", PROPERTY_TYPE::VECTOR3, m_transform.getOrientationEulerDeg());
-	properties.emplace_back("Scale", PROPERTY_TYPE::VECTOR3, m_transform.getScale());
-	//no material property
-
-	properties.emplace_back("Animation parameters", PROPERTY_TYPE::LABEL, nullptr);
-	properties.emplace_back("Play", PROPERTY_TYPE::BOOLEAN_FIELD, m_playAnimation, Global::m_tooltipMessages.node_playAnimation);
-	properties.emplace_back("Loop", PROPERTY_TYPE::BOOLEAN_FIELD, m_loopAnimation, Global::m_tooltipMessages.node_loopAnimation);
-	properties.emplace_back("Animation", PROPERTY_TYPE::ITEM_LIST, (m_showAllAnimations) ? m_animNamesFull : m_animNamesRestricted);
-	properties.emplace_back("Show all", PROPERTY_TYPE::BOOLEAN_FIELD, m_showAllAnimations, Global::m_tooltipMessages.node_showAllAnimation);
-
-	//TODO dropdown list for animations and a tick box for the loop param
-
-	return properties;
-}
-
-
-/**
- * A user changed a property
- */
-void ModelNode::setProperty(const std::string& p_name, std::any p_value)
-{
-	if (p_name == "Play") {
-		m_playAnimation = std::any_cast<bool>(p_value);
-		return;
-	}
-	if (p_name == "Loop") {
-		m_loopAnimation = std::any_cast<bool>(p_value);
-		return;
-
-	}
-	if (p_name == "Animation") {
-		if (m_showAllAnimations)
-		{
-			setCurrentAnimation(std::any_cast<int>(p_value));
-		}
-		else
-		{
-			setCurrentAnimation(getAnimFromRestricted(std::any_cast<int>(p_value)));
-		}
-		return;
-	}
-	if (p_name == "Show all") {
-		m_showAllAnimations = std::any_cast<bool>(p_value);
-		return;
-	}
-
-	BaseNode::setProperty(p_name, p_value);
-}
-
-
-/**
- * Get the animation's name
- */
-std::string ModelNode::getCurrentAnimationName() const
-{
-	return getCurrentAnimation()->m_playerFacingName;
-}
-
-
-/**
  * Get the model
  */
-ofxAssimpModelLoader& ModelNode::getModel()
+ofxCustomAssimpModelLoader& ModelNode::getModel()
 {
 	return m_model;
-}
-
-
-/**
- * Destructor
- */
-ModelNode::~ModelNode()
-{
-}
-
-
-/**
- * Prepare animations for use
- */
-void ModelNode::initAnimationsList()
-{
-	bool addAnimation = true;
-	std::string animName;
-	for (unsigned int i = 0; i < m_model.getAnimationCount(); i++, addAnimation = true)
-	{
-		for (auto anim : m_animations)
-		{
-			if (anim->m_devName == m_model.getAnimation(i).getAnimation()->mName.data)
-			{
-				addAnimation = false;
-				break;
-			}
-		}
-		if (addAnimation)
-		{
-			animName = m_model.getAnimation(i).getAnimation()->mName.data;
-			ModelNodeAnimationData* animData = new ModelNodeAnimationData(i, animName, makePlayerFacingName(animName));
-			m_animations.push_back(animData);
-		}
-	}
-	m_currentAnimID = getAnimFromRestricted(stoi(m_animNamesRestricted.back()));
-
-}
-
-
-/**
- * I hate this so much (hardcoded names)
- */
-void ModelNode::initHardcodedList()
-{
-	// Partial list
-	m_animNamesRestricted.push_back(makePlayerFacingName("2H_Melee_Idle"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Cheer"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Death_A_Pose"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Death_B_Pose"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Idle"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Lie_Idle"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Lie_Pose"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Running_A"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Running_B"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Sit_Chair_Idle"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Sit_Chair_Pose"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Sit_Floor_Idle"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Sit_Floor_Pose"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Spellcasting"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("T-Pose"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Unarmed_Idle"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Unarmed_Pose"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Walking_A"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Walking_B"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Walking_Backwards"));
-	m_animNamesRestricted.push_back(makePlayerFacingName("Walking_C"));
-	m_animNamesRestricted.push_back(m_DEFAULT_RESTRICTED_ANIM);
-	//Recording the position at the back makes it easier to deal with this list everywhere
-
-	// Full list
-	m_animNamesFull.push_back(makePlayerFacingName("1H_Melee_Attack_Chop"));
-	m_animNamesFull.push_back(makePlayerFacingName("1H_Melee_Attack_Slice_Diagonal"));
-	m_animNamesFull.push_back(makePlayerFacingName("1H_Melee_Attack_Slice_Horizontal"));
-	m_animNamesFull.push_back(makePlayerFacingName("1H_Melee_Attack_Stab"));
-	m_animNamesFull.push_back(makePlayerFacingName("1H_Ranged_Aiming"));
-	m_animNamesFull.push_back(makePlayerFacingName("1H_Ranged_Reload"));
-	m_animNamesFull.push_back(makePlayerFacingName("1H_Ranged_Shoot"));
-	m_animNamesFull.push_back(makePlayerFacingName("1H_Ranged_Shooting"));
-	m_animNamesFull.push_back(makePlayerFacingName("2H_Melee_Attack_Chop"));
-	m_animNamesFull.push_back(makePlayerFacingName("2H_Melee_Attack_Slice"));
-	m_animNamesFull.push_back(makePlayerFacingName("2H_Melee_Attack_Spin"));
-	m_animNamesFull.push_back(makePlayerFacingName("2H_Melee_Attack_Spinning"));
-	m_animNamesFull.push_back(makePlayerFacingName("2H_Melee_Attack_Stab"));
-	m_animNamesFull.push_back(makePlayerFacingName("2H_Melee_Idle"));
-	m_animNamesFull.push_back(makePlayerFacingName("2H_Ranged_Aiming"));
-	m_animNamesFull.push_back(makePlayerFacingName("2H_Ranged_Reload"));
-	m_animNamesFull.push_back(makePlayerFacingName("2H_Ranged_Shoot"));
-	m_animNamesFull.push_back(makePlayerFacingName("2H_Ranged_Shooting"));
-	m_animNamesFull.push_back(makePlayerFacingName("Block"));
-	m_animNamesFull.push_back(makePlayerFacingName("Block_Attack"));
-	m_animNamesFull.push_back(makePlayerFacingName("Block_Hit"));
-	m_animNamesFull.push_back(makePlayerFacingName("Blocking"));
-	m_animNamesFull.push_back(makePlayerFacingName("Cheer"));
-	m_animNamesFull.push_back(makePlayerFacingName("Death_A"));
-	m_animNamesFull.push_back(makePlayerFacingName("Death_A_Pose"));
-	m_animNamesFull.push_back(makePlayerFacingName("Death_B"));
-	m_animNamesFull.push_back(makePlayerFacingName("Death_B_Pose"));
-	m_animNamesFull.push_back(makePlayerFacingName("Dodge_Backward"));
-	m_animNamesFull.push_back(makePlayerFacingName("Dodge_Forward"));
-	m_animNamesFull.push_back(makePlayerFacingName("Dodge_Left"));
-	m_animNamesFull.push_back(makePlayerFacingName("Dodge_Right"));
-	m_animNamesFull.push_back(makePlayerFacingName("Dualwield_Melee_Attack_Chop"));
-	m_animNamesFull.push_back(makePlayerFacingName("Dualwield_Melee_Attack_Slice"));
-	m_animNamesFull.push_back(makePlayerFacingName("Dualwield_Melee_Attack_Stab"));
-	m_animNamesFull.push_back(makePlayerFacingName("Hit_A"));
-	m_animNamesFull.push_back(makePlayerFacingName("Hit_B"));
-	m_animNamesFull.push_back(makePlayerFacingName("Idle"));
-	m_animNamesFull.push_back(makePlayerFacingName("Interact"));
-	m_animNamesFull.push_back(makePlayerFacingName("Jump_Full_Long"));
-	m_animNamesFull.push_back(makePlayerFacingName("Jump_Full_Short"));
-	m_animNamesFull.push_back(makePlayerFacingName("Jump_Idle"));
-	m_animNamesFull.push_back(makePlayerFacingName("Jump_Land"));
-	m_animNamesFull.push_back(makePlayerFacingName("Jump_Start"));
-	m_animNamesFull.push_back(makePlayerFacingName("Lie_Down"));
-	m_animNamesFull.push_back(makePlayerFacingName("Lie_Idle"));
-	m_animNamesFull.push_back(makePlayerFacingName("Lie_Pose"));
-	m_animNamesFull.push_back(makePlayerFacingName("Lie_StandUp"));
-	m_animNamesFull.push_back(makePlayerFacingName("PickUp"));
-	m_animNamesFull.push_back(makePlayerFacingName("Running_A"));
-	m_animNamesFull.push_back(makePlayerFacingName("Running_B"));
-	m_animNamesFull.push_back(makePlayerFacingName("Running_Strafe_Left"));
-	m_animNamesFull.push_back(makePlayerFacingName("Running_Strafe_Right"));
-	m_animNamesFull.push_back(makePlayerFacingName("Sit_Chair_Down"));
-	m_animNamesFull.push_back(makePlayerFacingName("Sit_Chair_Idle"));
-	m_animNamesFull.push_back(makePlayerFacingName("Sit_Chair_Pose"));
-	m_animNamesFull.push_back(makePlayerFacingName("Sit_Chair_StandUp"));
-	m_animNamesFull.push_back(makePlayerFacingName("Sit_Floor_Down"));
-	m_animNamesFull.push_back(makePlayerFacingName("Sit_Floor_Idle"));
-	m_animNamesFull.push_back(makePlayerFacingName("Sit_Floor_Pose"));
-	m_animNamesFull.push_back(makePlayerFacingName("Sit_Floor_StandUp"));
-	m_animNamesFull.push_back(makePlayerFacingName("Spellcast_Long"));
-	m_animNamesFull.push_back(makePlayerFacingName("Spellcast_Raise"));
-	m_animNamesFull.push_back(makePlayerFacingName("Spellcast_Shoot"));
-	m_animNamesFull.push_back(makePlayerFacingName("Spellcasting"));
-	m_animNamesFull.push_back(makePlayerFacingName("T-Pose"));
-	m_animNamesFull.push_back(makePlayerFacingName("Throw"));
-	m_animNamesFull.push_back(makePlayerFacingName("Unarmed_Idle"));
-	m_animNamesFull.push_back(makePlayerFacingName("Unarmed_Melee_Attack_Kick"));
-	m_animNamesFull.push_back(makePlayerFacingName("Unarmed_Melee_Attack_Punch_A"));
-	m_animNamesFull.push_back(makePlayerFacingName("Unarmed_Melee_Attack_Punch_B"));
-	m_animNamesFull.push_back(makePlayerFacingName("Unarmed_Pose"));
-	m_animNamesFull.push_back(makePlayerFacingName("Use_Item"));
-	m_animNamesFull.push_back(makePlayerFacingName("Walking_A"));
-	m_animNamesFull.push_back(makePlayerFacingName("Walking_B"));
-	m_animNamesFull.push_back(makePlayerFacingName("Walking_Backwards"));
-	m_animNamesFull.push_back(makePlayerFacingName("Walking_C"));
-	m_animNamesFull.push_back(makePlayerFacingName(m_DEFAULT_FULL_ANIM));
-
-}
-
-
-/**
- * Get pointer to the current animation
- */
-ModelNodeAnimationData* ModelNode::getCurrentAnimation() const
-{
-	return m_animations.at(m_currentAnimID);
-}
-
-
-/**
- * Get the current animation ID
- */
-int ModelNode::getCurrentAnimationID() const
-{
-	return m_currentAnimID;
-}
-
-
-/**
- * Update the current animation
- */
-void ModelNode::setCurrentAnimation(int p_ID)
-{
-	if (!(p_ID == m_previousAnimID))
-	{
-		m_model.getAnimation(m_animations.at(m_previousAnimID)->m_animationID).stop();
-		m_previousAnimID = m_currentAnimID;
-		m_currentAnimID = p_ID;
-		m_animNamesFull.back() = std::to_string(p_ID);
-		setAnimInRestricted(p_ID);
-		m_model.getAnimation(m_animations.at(getCurrentAnimationID())->m_animationID).play();
-	}
-}
-
-
-/**
- * Set looping or play once
- */
-void ModelNode::setLoopingState(bool p_isLooping)
-{
-	m_loopAnimation = p_isLooping;
-
-	m_model.getAnimation(m_animations.at(getCurrentAnimationID())->m_animationID).stop();
-	(m_loopAnimation) ? m_model.setLoopStateForAllAnimations(OF_LOOP_NORMAL) : m_model.setLoopStateForAllAnimations(OF_LOOP_NONE);
-	m_model.getAnimation(m_animations.at(getCurrentAnimationID())->m_animationID).play();
-
-}
-
-
-/**
- * From an index in the restricted list, find the actual animation in the full list
- */
-int ModelNode::getAnimFromRestricted(int p_index)
-{
-	std::string nameToFind = m_animNamesRestricted.at(p_index);
-	for (auto anim : m_animations)
-	{
-		if (anim->m_playerFacingName == nameToFind)
-		{
-			return anim->m_animationID;
-		}
-	}
-	return -1;
-}
-
-
-/**
- * From a name, find the anim's index in the limited list and record it
- */
-void ModelNode::setAnimInRestricted(int p_index)
-{
-	std::string nameToFind = m_animations.at(p_index)->m_playerFacingName;
-	bool isFound = false;
-	for (size_t i = 0; i < m_animNamesRestricted.size(); i++)
-	{
-		if (m_animNamesRestricted.at(i) == nameToFind)
-		{
-			m_animNamesRestricted.back() = std::to_string(i);
-			isFound = true;
-			break;
-		}
-	}
-	if (!isFound) {
-		m_animNamesRestricted.back() = m_DEFAULT_RESTRICTED_ANIM;
-	}
-
 }
 
 
@@ -463,12 +203,11 @@ std::string ModelNode::makePlayerFacingName(const std::string& p_name)
 	return playerFacingName;
 }
 
-void ModelNode::debugPrintNames() const
+
+/**
+ * Destructor
+ */
+ModelNode::~ModelNode()
 {
-	ofLog() << "----------------------------";
-	ofLog() << "- Printing names for [" << m_name << "]";
-	for (auto anim : m_animations)
-	{
-		ofLog() << " --- Anim: " << anim->m_animationID << " : " << anim->m_devName << " (Player facing name: " << anim->m_playerFacingName << ")" ;
-	}
+	//todo
 }

--- a/src/nodes/ModelNode.h
+++ b/src/nodes/ModelNode.h
@@ -12,61 +12,43 @@
 #include "ofMain.h"
 #include "ofxCustomAssimpModelLoader.h"
 #include "Global.h"
+#include "ModelManager.h"
 #include <vector>
-
-
-struct ModelNodeAnimationData
-{
-	ModelNodeAnimationData(int p_id, const std::string& p_dName, const std::string& p_pName) : m_animationID(p_id), m_devName(p_dName), m_playerFacingName(p_pName)	{}
-	int m_animationID;
-	std::string m_devName;
-	std::string m_playerFacingName;
-};
 
 
 class ModelNode : public BaseNode {
 
 private:
 	ofxCustomAssimpModelLoader m_model;
+	const MODEL_TYPE m_modelType;
+	std::string m_fileBaseName;
+	int m_modelNo = 0;
 	ofVec3f m_bounds;
-	bool m_playAnimation = true;
-	bool m_loopAnimation = false;
-	bool m_showAllAnimations = false;
-	const std::string m_DEFAULT_RESTRICTED_ANIM = "4";  // the number here means "Idle", which is ID 36 in the full list
-	const std::string m_DEFAULT_FULL_ANIM = "36";
-	std::vector<ModelNodeAnimationData*> m_animations;
-	std::vector<std::string> m_animNamesRestricted; // used for showing them to the user
-	std::vector<std::string> m_animNamesFull;
-	int m_previousAnimID;
-	int m_currentAnimID;
 
 public:
-	explicit ModelNode(const std::string& p_name, const std::string& p_filePath);
+	explicit ModelNode(const std::string& p_nodeName, const std::string& p_fileBaseName, MODEL_TYPE p_modelType);
+
+protected:
+	void updateModel(int p_modelNo);
+	void updateModel(const std::string& p_modelName);
+
+public:
+	std::vector<NodeProperty> getProperties() const override;
+	void setProperty(const std::string& p_name, std::any p_value) override;
 	void setPosition(ofVec3f p_pos);
 	void setPosition(float p_x, float p_y, float p_z);
 	int draw(bool p_objectPicking, Camera* p_camera) override;
 	int endDraw(bool p_objectPicking, Camera* p_camera);
 	ofVec3f getBoundingBox() const override;
-	std::vector<NodeProperty> getProperties() const override;
-	void setProperty(const std::string& p_name, std::any p_value) override;
-	void setCurrentAnimation(int p_ID);
-	void setLoopingState(bool p_isLooping);
-	std::string getCurrentAnimationName() const;
-	ofxAssimpModelLoader& getModel();
+	ofxCustomAssimpModelLoader& getModel();
+
+protected:
+	std::string makePlayerFacingName(const std::string& p_name);
+	void updateBoundingBox();
 	~ModelNode();
 
 private:
-	void initHardcodedList();
-	void initAnimationsList();
-	ModelNodeAnimationData* getCurrentAnimation() const;
-	int getCurrentAnimationID() const;
-	int getAnimFromRestricted(int p_index);
-	void setAnimInRestricted(int p_index);
-
-	void updateBoundingBox();
+	void loadModel(const std::string& p_filePath);
 	void drawBoundingBox();
-
-	std::string makePlayerFacingName(const std::string& p_name);
-	void debugPrintNames() const;
 
 };

--- a/src/nodes/NodeProperty.h
+++ b/src/nodes/NodeProperty.h
@@ -1,5 +1,5 @@
 /*****************************************************
-* TP IFT3100H25 - Adventure Party Maker
+ * TP IFT3100H25 - Adventure Party Maker
  * by Team 12
  *****************************************************
  *
@@ -18,7 +18,8 @@ enum PROPERTY_TYPE {
 	LABEL,
 	BOOLEAN_FIELD,
 	INT_FIELD,
-	ITEM_LIST
+	ITEM_LIST,
+	MODEL_LIST
 };
 
 

--- a/src/openFrameworks/ofxCustomAssimpModelLoader.cpp
+++ b/src/openFrameworks/ofxCustomAssimpModelLoader.cpp
@@ -66,15 +66,15 @@ void ofxCustomAssimpModelLoader::draw(ofPolyRenderMode renderType) {
         mesh.vbo.drawElements(GL_TRIANGLES,mesh.indices.size());
 #else
         switch(renderType){
-            case OF_MESH_FILL:
+        case OF_MESH_FILL:
                 mesh.vbo.drawElements(GL_TRIANGLES,mesh.indices.size());
             break;
-            case OF_MESH_WIREFRAME:
-                //note this won't look the same as on non ES renderers.
-                    //there is no easy way to convert GL_TRIANGLES to outlines for each triangle
+        case OF_MESH_WIREFRAME:
+            //note this won't look the same as on non ES renderers.
+                //there is no easy way to convert GL_TRIANGLES to outlines for each triangle
                         mesh.vbo.drawElements(GL_LINES,mesh.indices.size());
             break;
-            case OF_MESH_POINTS:
+        case OF_MESH_POINTS:
                 mesh.vbo.drawElements(GL_POINTS,mesh.indices.size());
             break;
         }
@@ -110,7 +110,7 @@ void ofxCustomAssimpModelLoader::draw(ofPolyRenderMode renderType) {
 
 
 /**
- * Called after load, we create our list of enable mesesh
+ * Called after load, we create our list of enable meshes
  */
 bool ofxCustomAssimpModelLoader::createEnabledMeshes() {
     bool result = ofxAssimpModelLoader::processScene();
@@ -148,14 +148,14 @@ void ofxCustomAssimpModelLoader::setMeshEnabled(int p_index, bool p_value) {
 /**
  * Load model and enable specific meshes
  */
-bool ofxCustomAssimpModelLoader::loadModel(const std::string & p_filename) {
-    bool result = ofxAssimpModelLoader::loadModel(p_filename);
+bool ofxCustomAssimpModelLoader::load(const std::string& p_filename) {
+    bool result = ofxAssimpModelLoader::load(p_filename, ofxAssimpModelLoader::OPTIMIZE_DEFAULT);
     createEnabledMeshes();
 
     ofFile file(p_filename + ".disabled");
     if (file.exists()) {
         ofBuffer buffer(file);
-        for (auto &line : buffer.getLines()) {
+        for (auto& line : buffer.getLines()) {
             setMeshEnabled(line, false);
         }
     }

--- a/src/openFrameworks/ofxCustomAssimpModelLoader.h
+++ b/src/openFrameworks/ofxCustomAssimpModelLoader.h
@@ -9,7 +9,7 @@ private:
     bool createEnabledMeshes();
 
 public:
-    bool loadModel(const std::string & p_filename);
+    bool load(const std::string & p_filename);
     void draw(ofPolyRenderMode renderType);
     void drawFaces();
     void setMeshEnabled(const std::string& p_meshName, bool p_value);

--- a/src/ui/AddNodeDialog.cpp
+++ b/src/ui/AddNodeDialog.cpp
@@ -1,5 +1,5 @@
 /*****************************************************
-* TP IFT3100H25 - Adventure Party Maker
+ * TP IFT3100H25 - Adventure Party Maker
  * by Team 12
  *****************************************************
  *
@@ -16,15 +16,17 @@
 #include <GroupNode.h>
 #include <imgui.h>
 #include <ModelNode.h>
+#include <CharacterNode.h>
+#include <AssetNode.h>
 #include <ofLog.h>
 #include <PlaneNode.h>
 #include <SphereNode.h>
 #include <TerrainNode.h>
 
 
-/**
- * Constructor
- */
+ /**
+  * Constructor
+  */
 AddNodeDialog::AddNodeDialog() : ModalDialog() {
 
     setTitle("Add Node");
@@ -179,22 +181,46 @@ void AddNodeDialog::draw() {
             Global::m_selectedFromViewport = true;
         }
 
-        // Primitives
+        // Models
         ImGui::Dummy(ImVec2(0, 5));
-        ImGui::TextColored(ImVec4(1, 0.5, 0.5, 1), "Others");
+        ImGui::TextColored(ImVec4(1, 0.5, 0.5, 1), "Models");
 
-        // Add model
-        if (ImGui::Button("Model", ImVec2(200,20))) {
+        // Add character
+        if (ImGui::Button("Character", ImVec2(200, 20))) {
             ImGui::CloseCurrentPopup();
             m_isOpen = false;
 
             BaseNode* parent;
             if (Global::m_selectedNode == -1) {
                 parent = Global::m_level.getTree();
-            } else {
+            }
+            else {
                 parent = Global::m_level.getTree()->findNode(Global::m_selectedNode);
             }
-            ModelNode* childNode = new ModelNode("Model", "Kaykit/Characters/gltf/Knight.glb");
+            CharacterNode* childNode = new CharacterNode();
+            parent->addChild(childNode);
+
+            if (Global::m_selectedNode != -1) {
+                Global::m_level.getTree()->findNode(Global::m_selectedNode)->displayBoundingBox(false);
+            }
+            childNode->displayBoundingBox(true);
+            Global::m_selectedNode = childNode->getId();
+            Global::m_selectedFromViewport = true;
+        }
+
+        // Add asset
+        if (ImGui::Button("Asset", ImVec2(200, 20))) {
+            ImGui::CloseCurrentPopup();
+            m_isOpen = false;
+
+            BaseNode* parent;
+            if (Global::m_selectedNode == -1) {
+                parent = Global::m_level.getTree();
+            }
+            else {
+                parent = Global::m_level.getTree()->findNode(Global::m_selectedNode);
+            }
+            AssetNode* childNode = new AssetNode();
             parent->addChild(childNode);
 
             if (Global::m_selectedNode != -1) {
@@ -206,6 +232,8 @@ void AddNodeDialog::draw() {
         }
 
         // Add terrain
+        ImGui::Dummy(ImVec2(0, 5));
+        ImGui::TextColored(ImVec4(1, 0.5, 0.5, 1), "Terrain");
         if (ImGui::Button("Terrain", ImVec2(200, 20))) {
             ImGui::CloseCurrentPopup();
             m_isOpen = false;
@@ -231,7 +259,7 @@ void AddNodeDialog::draw() {
             Global::m_selectedFromViewport = true;
         }
 
-		ImGui::Dummy(ImVec2(0.0f, 5.0f));
+        ImGui::Dummy(ImVec2(0.0f, 5.0f));
         ImGui::Separator();
         ImGui::Dummy(ImVec2(0.0f, 5.0f));
 

--- a/src/ui/TooltipMessages.hpp
+++ b/src/ui/TooltipMessages.hpp
@@ -1,5 +1,5 @@
 /*****************************************************
-* TP IFT3100H25 - Adventure Party Maker
+ * TP IFT3100H25 - Adventure Party Maker
  * by Team 12
  *****************************************************
  *
@@ -17,10 +17,10 @@ struct TooltipMessages {
 	// BaseNode
 	const char* node_display = "If ticked, the node is rendered to the screen. \nUntick to hide the node.";
 
-	// ModelNode
+	// Character, Asset, and Model Node
+	const char* node_model = "Change the model's visual.";
 	const char* node_playAnimation = "If ticked, the model will update their animation. \nWhen unticked, the animation stops updating \nleaving the character in its current pose.";
-	const char* node_loopAnimation = "If ticked, the model will play the currently \nassigned animation on a loop. \nMake sure 'Play' is ticked if you want it to play. \n\nTODO: refactor this to a button and make it work! :)";
-	const char* node_showAllAnimation = "If ticked, the list above will show all available animations \nfor the character, even those that are not looping.";
+	const char* node_showAllAnimation = "If ticked, the list above will show all \n available animations for the character";
 
 	//Camera options
 	const char* camera_orthoZoom = "Orthographic zoom factor";

--- a/src/ui/UserInterface.cpp
+++ b/src/ui/UserInterface.cpp
@@ -1,5 +1,5 @@
 /*****************************************************
-* TP IFT3100H25 - Adventure Party Maker
+ * TP IFT3100H25 - Adventure Party Maker
  * by Team 12
  *****************************************************
  *
@@ -11,6 +11,7 @@
 #include <imgui_internal.h>
 #include <ofAppRunner.h>
 #include <ofGraphics.h>
+
 #ifdef _WIN32
 	#include <direct.h>
 	#define mkdir _mkdir
@@ -622,10 +623,9 @@ void UserInterface::drawProperties() {
 
 		case PROPERTY_TYPE::ITEM_LIST:
 		{
-
 			ImGui::Text(property.getName().c_str());
 			ImGui::SameLine(110);
-			auto value = std::any_cast<std::vector<std::string>>(property.getValue());
+			std::vector<std::string> value = std::any_cast<std::vector<std::string>>(property.getValue());
 
 			int initialSelection = stoi(value.back()); //get the index at the back of the vector
 			int currentItem = initialSelection;
@@ -641,6 +641,36 @@ void UserInterface::drawProperties() {
 			if (ImGui::Combo(("##List_" + std::to_string(count)).c_str(), &currentItem, cstrings.data(), cstrings.size()))
 			{
 				Global::m_actions.addAction(selectedNode, property.getName(), initialSelection, currentItem);
+			}
+			if (!property.getTooltip().empty()) {
+				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+				{
+					ImGui::SetTooltip(property.getTooltip().c_str());
+				}
+			}
+
+		}
+		break;
+
+		case PROPERTY_TYPE::MODEL_LIST:
+		{
+			// Exclusively for listing models.
+			// Used by CharacterNodes and AssetNodes
+			// Gets the clist from the ModelManager
+			ImGui::Text(property.getName().c_str());
+			ImGui::SameLine(110);
+			std::pair<int, MODEL_TYPE>  value = std::any_cast<std::pair<int, MODEL_TYPE>>(property.getValue());
+			int currentItem = value.first;
+
+			ImGui::PushItemWidth(186.0f);
+			if (ImGui::Combo(
+				("##List_" + std::to_string(count)).c_str(),
+				&currentItem,
+				Global::m_modelManager.getCNames(value.second).data(),
+				Global::m_modelManager.getCNames(value.second).size())
+				)
+			{
+				Global::m_actions.addAction(selectedNode, property.getName(), value.first, currentItem);
 			}
 			if (!property.getTooltip().empty()) {
 				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))


### PR DESCRIPTION
Changes:
- Created CharacterNode, AssetNode, and ModelManager classes
- Stripped down ModelNode class (functionalities moved to the appropriate new class)
- Added a MODEL_LIST property to simplify implementation of model choices in ImGui
- Added Character and Asset to the list in AddNodeDialog
- Updated ofxCustomAssimpModelLoader to use "load" instead of the deprecated "loadModel"
- Reduced number of animations available in the restricted list
- Fixed bug where the animation didn't update after making a selection
- Added a "Loot" group to the level with 2 assets to demonstrate the feature
- Removed option to set animations to non-looping (didn't work and would never feel good anyways)
- Fixed typo in README