### PR TITLE
Added criteria 6.1 on CharacterNode

### DIFF
--- a/src/Level.cpp
+++ b/src/Level.cpp
@@ -125,13 +125,6 @@ void test_spawn_sphere(BaseNode* tree, int sphere_count, float sphere_spacing, f
 }
 
 
-void test_print_modelNode_positions(ModelNode* p_node)
-{
-	ofLog() << p_node->getName() << " : " << p_node->getModel().getPosition().x << " : " << p_node->getModel().getPosition().y << " : " << p_node->getModel().getPosition().z;
-	ofLog() << p_node->getName() << " : " << p_node->getTransform().getPosition().x << " : " << p_node->getTransform().getPosition().y << " : " << p_node->getTransform().getPosition().z;
-}
-
-
 /**
  * Reset level
  */
@@ -140,7 +133,6 @@ void Level::reset() {
 	//--- Group of 5 adventurers. 
 	// The user can add the knight via the "Add Node" button (it's more insteresting to use if they are not addding a duplicate)
 	GroupNode* adventurer_group = new GroupNode("Adventurers");
-	//adventurer_group->getTransform().setOrientation(glm::vec3(0, 0, 0));
 	m_tree->addChild(adventurer_group);
 
 	CharacterNode* node_rogue = new CharacterNode("Rogue", "Rogue");

--- a/src/nodes/CharacterNode.h
+++ b/src/nodes/CharacterNode.h
@@ -33,6 +33,7 @@ private:
 	std::vector<std::string> m_animNamesRestricted; // used for showing them to the user
 	std::vector<std::string> m_animNamesFull;
 	int m_currentAnimID;
+	int m_textureNo = 0;
 	
 public:
 	CharacterNode(const std::string& p_name = "New Character", const std::string& p_fileBaseName = "");

--- a/src/nodes/ModelManager.h
+++ b/src/nodes/ModelManager.h
@@ -8,10 +8,9 @@
  *****************************************************/
 #pragma once
 #include <vector>
+#include <map>
 #include <string>
 #include <ofxXmlSettings.h>
-//#include <memory>
-//#include <sstream>
 #include "ofMain.h"
 #include "ofxCustomAssimpModelLoader.h"
 
@@ -32,15 +31,58 @@ class ModelManager
 {
 	//variables
 private:
-	const std::string m_charactersPath = "KayKit/Characters/gltf";
-	const std::string m_assetsPath = "KayKit/Assets/gltf";
-	const std::string m_animPath = "KayKit/Characters/gltf/Animations.xml";
-	const std::string m_charactersExtension = "glb";
-	const std::string m_assetsExtension = "gltf";
+	const std::string m_CHARACTERS_PATH = "KayKit/Characters/gltf";
+	const std::string m_ASSETS_PATH = "KayKit/Assets/gltf";
+	const std::string m_CHARACTERS_EXTENSION = "glb";
+	const std::string m_ASSETS_EXTENSION = "gltf";
+	
+	// Model names
 	std::vector<std::string> m_characterStrNames;
 	std::vector<std::string> m_assetStrNames;
 	std::vector<char*> m_characterCNames;
 	std::vector<char*> m_assetCNames;
+
+	// Character textures
+	const std::string m_CHARACTER_TEXTURE_PATH = "KayKit/Textures";
+	const std::vector<std::string> m_CHARACTER_TEXTURE_FILE_NAMES{ "texture.png", "texture_alt_A.png", "texture_alt_B.png", "texture_alt_C.png" };
+	std::map<int, std::array<ofTexture, 4>> m_characterTextures;
+	const std::map<std::string, std::vector<char*>> m_CHARACTER_TEXTURE_NAMES{
+		{"Barbarian", {
+			"Ice moose",
+			"Clover fox",
+			"Sun wolf",
+			"Dirt bear"}},
+		{"Druid", {
+			"Forest strider",
+			"Tundra dweller",
+			"Ash walker",
+			"Desert drifter" }},
+		{"Engineer", {
+			"Copper mechanic",
+			"Steel plumber",
+			"Cobalt wireman",
+			"Pyrite mason"}},
+		{"Knight", {
+			"Steely heart",
+			"Pale fir",
+			"Golden stone",
+			"Crimson snow"}},
+		{"Mage", {
+			"Emerald necromancer",
+			"Aquamarine brewmaster",
+			"Topaz herbalist",
+			"Amethyst transmuter"}},
+		{"Rogue", {
+			"Green poisoner",
+			"Silver swindler",
+			"Motley arsonist",
+			"Pink assassin"}},
+		{"Rogue_Hooded", {
+			"Green poisoner",
+			"Silver arsonist",
+			"Motley robber",
+			"Pink assassin"}},
+	};
 	
 	//functions
 public: 
@@ -48,12 +90,15 @@ public:
 private:
 	void listNames(std::vector<std::string>& p_list, const std::string& p_directoryPath, const std::string& p_fileExtension);
 	void listCNames(std::vector<std::string>& p_list, std::vector<char*>& p_cList);
+	void loadCharacterTextures();
 public:
 	const std::vector<char*> getCNames(MODEL_TYPE p_type);
+	const std::vector<char*> getCTexNames(int p_index, MODEL_TYPE p_type = MODEL_TYPE::CHARACTER);
 	std::string getModelPath(const std::string& p_name, MODEL_TYPE p_type);
 	std::string getModelPath(int p_cIndex, MODEL_TYPE p_type);
 	std::string getModelName(int p_index, MODEL_TYPE p_type);
 	std::string getRandom(MODEL_TYPE p_type);
 	int getModelNo(const std::string& p_name, MODEL_TYPE p_type);
+	const ofTexture& getTexture(int p_characterIndex, int p_textureIndex, MODEL_TYPE p_type = MODEL_TYPE::CHARACTER);
 };
 

--- a/src/nodes/ModelNode.cpp
+++ b/src/nodes/ModelNode.cpp
@@ -60,8 +60,8 @@ std::vector<NodeProperty> ModelNode::getProperties() const
 	//no material property for models
 
 	//model property
-	properties.emplace_back("Model parameter", PROPERTY_TYPE::LABEL, nullptr);
-	properties.emplace_back("Model", PROPERTY_TYPE::MODEL_LIST, std::make_pair(m_modelNo, m_modelType), Global::m_tooltipMessages.node_model);
+	properties.emplace_back("Model parameters", PROPERTY_TYPE::LABEL, nullptr);
+	properties.emplace_back("Model", PROPERTY_TYPE::ITEM_CLIST, std::make_pair(m_modelNo, Global::m_modelManager.getCNames(m_modelType)), Global::m_tooltipMessages.node_model);
 
 	return properties;
 }

--- a/src/nodes/ModelNode.h
+++ b/src/nodes/ModelNode.h
@@ -20,10 +20,11 @@ class ModelNode : public BaseNode {
 
 private:
 	ofxCustomAssimpModelLoader m_model;
-	const MODEL_TYPE m_modelType;
 	std::string m_fileBaseName;
-	int m_modelNo = 0;
 	ofVec3f m_bounds;
+protected:
+	int m_modelNo = 0;
+	const MODEL_TYPE m_modelType;
 
 public:
 	explicit ModelNode(const std::string& p_nodeName, const std::string& p_fileBaseName, MODEL_TYPE p_modelType);

--- a/src/nodes/NodeProperty.h
+++ b/src/nodes/NodeProperty.h
@@ -18,8 +18,8 @@ enum PROPERTY_TYPE {
 	LABEL,
 	BOOLEAN_FIELD,
 	INT_FIELD,
-	ITEM_LIST,
-	MODEL_LIST
+	ITEM_LIST, //pass a std::vector<std::string> with the currentItem placed at the back
+	ITEM_CLIST, //pass a std::pair<int, std::vector<char*>>: first is the currenItem and second is the list of options
 };
 
 

--- a/src/ui/TooltipMessages.hpp
+++ b/src/ui/TooltipMessages.hpp
@@ -19,6 +19,7 @@ struct TooltipMessages {
 
 	// Character, Asset, and Model Node
 	const char* node_model = "Change the model's visual.";
+	const char* node_modelTexture = "Change the model's texture.";
 	const char* node_playAnimation = "If ticked, the model will update their animation. \nWhen unticked, the animation stops updating \nleaving the character in its current pose.";
 	const char* node_showAllAnimation = "If ticked, the list above will show all \n available animations for the character";
 

--- a/src/ui/UserInterface.cpp
+++ b/src/ui/UserInterface.cpp
@@ -652,22 +652,19 @@ void UserInterface::drawProperties() {
 		}
 		break;
 
-		case PROPERTY_TYPE::MODEL_LIST:
+		case PROPERTY_TYPE::ITEM_CLIST:
 		{
-			// Exclusively for listing models.
-			// Used by CharacterNodes and AssetNodes
-			// Gets the clist from the ModelManager
 			ImGui::Text(property.getName().c_str());
 			ImGui::SameLine(110);
-			std::pair<int, MODEL_TYPE>  value = std::any_cast<std::pair<int, MODEL_TYPE>>(property.getValue());
+			std::pair<int, std::vector<char*>> value = std::any_cast<std::pair<int, std::vector<char*>>>(property.getValue());
 			int currentItem = value.first;
 
 			ImGui::PushItemWidth(186.0f);
 			if (ImGui::Combo(
 				("##List_" + std::to_string(count)).c_str(),
 				&currentItem,
-				Global::m_modelManager.getCNames(value.second).data(),
-				Global::m_modelManager.getCNames(value.second).size())
+				value.second.data(),
+				value.second.size())
 				)
 			{
 				Global::m_actions.addAction(selectedNode, property.getName(), value.first, currentItem);


### PR DESCRIPTION
- Texture parameter added on CharacterNode: allows the user to choose between 4 textures for each character types;
- Added a PROPERTY_TYPE::ITEM_CLIST, which is similar but imo more straightforward than the ITEM_LIST, it allowed the removal of the unique MODEL_LIST type.