### PR TITLE
Spline: fixed a crash, added button related to control points

### DIFF
--- a/src/nodes/NodeProperty.h
+++ b/src/nodes/NodeProperty.h
@@ -22,6 +22,7 @@ enum PROPERTY_TYPE {
 	ITEM_LIST, //Pass a std::vector<std::string> with the currentItem placed at the back
 	ITEM_CLIST, //Pass a std::pair<int, std::vector<const char*>>: first is the currenItem and second is the list of options
 	TEXT_INFO, //Use to display information about the node, for example the value of a variable that the user can't directly modify (i.e.: the index of a spline control point)
+	DUMB_BUTTON, //A simple button that does something when clicked. It takes a boolean value, but you don't have to use it (for a toggle, use BOOLEAN_FIELD instead)
 };
 
 

--- a/src/nodes/PerlinNoiseTexture.cpp
+++ b/src/nodes/PerlinNoiseTexture.cpp
@@ -1,6 +1,7 @@
 #include "PerlinNoiseTexture.h"
 
 #include <algorithm>
+#include <numeric>
 
 PerlinNoiseTexture::PerlinNoiseTexture(unsigned int seed) {
     p.resize(256);

--- a/src/nodes/SplineNode.h
+++ b/src/nodes/SplineNode.h
@@ -36,6 +36,9 @@ public:
 
     std::vector<NodeProperty> getProperties() const override;
     void removeAllChildren() override {}; // This class uses his own housekeeping functions
-    //void setProperty(const std::string& p_name, std::any p_value);
+    void setProperty(const std::string& p_name, std::any p_value);
+
+private:
+    void setDisplayNodeOnControlPoints(bool p_value);
 };
 

--- a/src/ui/UserInterface.cpp
+++ b/src/ui/UserInterface.cpp
@@ -827,6 +827,18 @@ void UserInterface::drawProperties() {
                 }
             }
             break;
+
+            case PROPERTY_TYPE::DUMB_BUTTON: {
+                bool value = std::any_cast<bool>(property.getValue());
+
+                if (ImGui::Button(property.getName().c_str())) {
+                    Global::m_actions.addAction(selectedNode, property.getName(), value, !value);
+                }
+                if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                    ImGui::SetTooltip(property.getTooltip().c_str());
+                }
+            }
+            break;
         }
 
         count++;


### PR DESCRIPTION
- The program shouldn't crash anymore when the last control point of a spline is deleted
- Splines now have 3 buttons: "Add" (a control point), "Display all" (control points) and "Hide all" (control points)